### PR TITLE
Non-english languages supporting

### DIFF
--- a/EndPointController/EndPointController.cpp
+++ b/EndPointController/EndPointController.cpp
@@ -39,6 +39,7 @@ void invalidParameterHandler(const wchar_t* expression, const wchar_t* function,
 // EndPointController.exe [NewDefaultDeviceID]
 int _tmain(int argc, LPCWSTR argv[])
 {
+	setlocale(LC_ALL, "");
 	TGlobalState state;
 
 	// Process command line arguments


### PR DESCRIPTION
Now non-english characters displayed correctly without "???".

See screenshot with output Before and After app's build here: https://pp.userapi.com/c824604/v824604076/202af/czH09xNkRT4.jpg

https://github.com/DanStevens/AudioEndPointController/pull/6